### PR TITLE
Improve stats, increase number of goroutines

### DIFF
--- a/clockpro.go
+++ b/clockpro.go
@@ -748,10 +748,10 @@ func New(size int64, postSet, postEvict func(string, uint64)) *Cache {
 				case <-ticker.C:
 					mc := c.Metrics()
 					runtime.ReadMemStats(&ms)
-					fmt.Fprintf(os.Stderr, "Limit: %vMB, Size: %vMB, Count: %v, Hits: %v, Misses: %v, AllocSize: %vMB;",
+					fmt.Fprintf(os.Stderr, "Limit: %vMB, Size: %vMB, Count: %v, Hits: %v, Misses: %v, AllocSize: %vMB\n",
 						uint64(size)/MB, uint64(mc.Size)/MB, mc.Count, mc.Hits, mc.Misses, uint64(atomic.LoadInt64(&manual.AllocSize))/MB)
-					fmt.Fprintf(os.Stderr, "HeapAlloc:%dMB, HeapSys:%dMB, HeapIdle:%dMB, HeapInuse:%dMB\n",
-						ms.HeapAlloc/MB, ms.HeapSys/MB, (ms.HeapIdle-ms.HeapReleased)/MB, ms.HeapInuse/MB)
+					fmt.Fprintf(os.Stderr, "HeapAlloc:%dMB, HeapSys:%dMB, HeapIdle:%dMB, HeapInuse:%dMB, Goroutines: %v\n",
+						ms.HeapAlloc/MB, ms.HeapSys/MB, (ms.HeapIdle-ms.HeapReleased)/MB, ms.HeapInuse/MB, runtime.NumGoroutine())
 				}
 			}
 		}


### PR DESCRIPTION
Improve the output format of stats to make it more visual, and add information about the number of goroutines to detect routine leaks.